### PR TITLE
feat(ui): 资源管理增强与导航中英文化修复

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,3 +47,4 @@
 - 2026-06-25：删除确认由浏览器原生 confirm 改为应用内统一弹窗（含入口信息、取消/确定删除按钮），避免系统弹窗风格突兀。
 - 2026-06-25：访问凭据页支持 Token 多次复制：创建时保存明文到本地（localStorage）并在已发放列表提供“复制 Token”按钮；删除 Token 时自动清理本地副本。
 - 2026-06-25：所有删除类操作统一走应用内确认弹窗（入口删除 / Token 删除 / 日志清空），并在弹窗中增加字段说明（字段名 + 字段值）后再确认执行。
+- 2026-06-25：资源管理列表新增“打开”按钮。对 `cloud.lazycat.app.lazycat-filedrop-skill` 与 `cloud.lazycat.app.lazycat-agent-browser-skill` 按规则拼接外部地址；三级域名不再硬编码，从懒猫应用返回的 `domain/subdomain` 自动提取（如 canway / nasw）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,3 +48,4 @@
 - 2026-06-25：访问凭据页支持 Token 多次复制：创建时保存明文到本地（localStorage）并在已发放列表提供“复制 Token”按钮；删除 Token 时自动清理本地副本。
 - 2026-06-25：所有删除类操作统一走应用内确认弹窗（入口删除 / Token 删除 / 日志清空），并在弹窗中增加字段说明（字段名 + 字段值）后再确认执行。
 - 2026-06-25：资源管理列表新增“打开”按钮。对 `cloud.lazycat.app.lazycat-filedrop-skill` 与 `cloud.lazycat.app.lazycat-agent-browser-skill` 按规则拼接外部地址；三级域名不再硬编码，从懒猫应用返回的 `domain/subdomain` 自动提取（如 canway / nasw）。
+- 2026-06-25：修复中英文切换下侧栏菜单不跟随语言的问题，导航文案改为双语字段并通过 `t(...)` 动态渲染（Overview / Management / Access tokens / Observability）。

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -5,10 +5,10 @@ import ViewShell from './components/ViewShell.vue'
 
 // ── Navigation ──
 const views = [
-  { key: 'overview',   label: '总览',       icon: '◉' },
-  { key: 'upstreams',  label: '资源管理',   icon: '◇' },
-  { key: 'access',     label: '访问凭据',   icon: '○' },
-  { key: 'observability', label: '调用观测', icon: '◎' }
+  { key: 'overview',   labelZh: '总览',     labelEn: 'Overview',      icon: '◉' },
+  { key: 'upstreams',  labelZh: '资源管理', labelEn: 'Management',    icon: '◇' },
+  { key: 'access',     labelZh: '访问凭据', labelEn: 'Access tokens', icon: '○' },
+  { key: 'observability', labelZh: '调用观测', labelEn: 'Observability', icon: '◎' }
 ]
 
 const THEME_STORAGE_KEY = 'lazycat-mcp-theme'
@@ -635,7 +635,7 @@ onBeforeUnmount(() => {
           @click="setActiveView(item.key)"
         >
           <span class="nav-icon">{{ item.icon }}</span>
-          <span class="nav-label">{{ item.label }}</span>
+          <span class="nav-label">{{ t(item.labelZh, item.labelEn) }}</span>
         </button>
       </nav>
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -69,6 +69,10 @@ let mediaQueryList = null
 let mediaQueryHandler = null
 let toastTimer = null
 const TOKEN_SECRET_STORAGE_KEY = 'lazycat-mcp-token-secrets'
+const OPEN_APP_TARGETS = {
+  'cloud.lazycat.app.lazycat-filedrop-skill': 'lazycat-filedrop',
+  'cloud.lazycat.app.lazycat-agent-browser-skill': 'lazycat-agent-browser'
+}
 
 const t = (zh, en) => state.language === 'en' ? en : zh
 
@@ -246,6 +250,52 @@ function providerHealthMeta(provider) {
 function upstreamStatusMeta(row) {
   if (!row.provider) return { tone: 'warn', text: t('待发布', 'Pending') }
   return row.provider.enabled ? { tone: 'ok', text: t('已上线', 'Live') } : { tone: 'soft', text: t('已下线', 'Offline') }
+}
+function normalizeDomain(value) {
+  if (!value) return ''
+  const trimmed = String(value).trim()
+  if (!trimmed) return ''
+  try {
+    if (trimmed.includes('://')) return new URL(trimmed).hostname.toLowerCase()
+  } catch {
+    return ''
+  }
+  return trimmed.replace(/^\.+|\.+$/g, '').toLowerCase()
+}
+function rootDomainFromHost(host) {
+  const normalized = normalizeDomain(host)
+  if (!normalized) return ''
+  const parts = normalized.split('.').filter(Boolean)
+  if (parts.length < 2) return ''
+  if (parts.length >= 4) return parts.slice(1).join('.')
+  return normalized
+}
+function openTargetPrefix(row) {
+  return OPEN_APP_TARGETS[row?.appId || row?.app?.app_id] || ''
+}
+function openRootDomain(row) {
+  const fromDomain = rootDomainFromHost(row?.app?.domain)
+  if (fromDomain) return fromDomain
+  const fromSubdomain = rootDomainFromHost(row?.app?.subdomain)
+  if (fromSubdomain) return fromSubdomain
+  return ''
+}
+function openURLForRow(row) {
+  const prefix = openTargetPrefix(row)
+  const root = openRootDomain(row)
+  if (!prefix || !root) return ''
+  return `https://${prefix}.${root}/`
+}
+function canOpenRow(row) {
+  return row?.kind === 'app' && !!openURLForRow(row)
+}
+function openApp(row) {
+  const url = openURLForRow(row)
+  if (!url) {
+    showToast(t('未获取到应用域名，无法自动打开', 'App domain not available, cannot open automatically'))
+    return
+  }
+  window.open(url, '_blank', 'noopener,noreferrer')
 }
 function viewUpstreamDetail(row) {
   detailRow.value = row
@@ -696,6 +746,7 @@ onBeforeUnmount(() => {
               <button v-if="row.provider?.enabled" type="button" class="row-btn row-btn-toggle" @click="setProviderEnabled(row.provider, false).catch((error) => showToast(error.message))">{{ t('下线', 'Offline') }}</button>
               <button v-if="row.provider && !row.provider.enabled && row.kind === 'app'" type="button" class="row-btn row-btn-publish" @click="openPublishDialog(row)">{{ t('重新发布', 'Republish') }}</button>
               <button v-if="row.provider" type="button" class="row-btn row-btn-delete" @click="askDeleteProvider(row.provider)">{{ t('删除', 'Delete') }}</button>
+              <button v-if="canOpenRow(row)" type="button" class="row-btn row-btn-open" @click="openApp(row)">{{ t('打开', 'Open') }}</button>
               <button type="button" class="row-btn row-btn-detail" @click="viewUpstreamDetail(row)">{{ t('详情', 'Detail') }}</button>
             </div>
           </div>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -278,6 +278,8 @@ function openRootDomain(row) {
   if (fromDomain) return fromDomain
   const fromSubdomain = rootDomainFromHost(row?.app?.subdomain)
   if (fromSubdomain) return fromSubdomain
+  const fromCurrent = rootDomainFromHost(window.location.hostname)
+  if (fromCurrent) return fromCurrent
   return ''
 }
 function openURLForRow(row) {

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -433,6 +433,14 @@ strong { font-weight: 600; }
 .row-btn-detail:hover {
   background: color-mix(in srgb, var(--info) 16%, transparent);
 }
+.row-btn-open {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 35%, var(--border));
+  color: var(--accent);
+}
+.row-btn-open:hover {
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
 
 .upstream-pagination {
   display: flex;


### PR DESCRIPTION
## 变更摘要
- 资源管理操作列新增“打开”按钮（按 app_id 映射）
- 打开链接根域自动解析（优先 app.domain/subdomain，缺失时回退当前域名）
- 修复侧栏菜单在中英文切换下未翻译的问题
- 统一删除确认弹窗并补充字段说明

## 验证
- [x] frontend: `npm run build`
- [x] backend: `/usr/local/go/bin/go test ./...`

## 说明
- 已按要求更新 `CHANGELOG.md`
