### PR TITLE
feat(ui): 资源管理打开按钮自动模式与中英文化优化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,3 +49,4 @@
 - 2026-06-25：所有删除类操作统一走应用内确认弹窗（入口删除 / Token 删除 / 日志清空），并在弹窗中增加字段说明（字段名 + 字段值）后再确认执行。
 - 2026-06-25：资源管理列表新增“打开”按钮。对 `cloud.lazycat.app.lazycat-filedrop-skill` 与 `cloud.lazycat.app.lazycat-agent-browser-skill` 按规则拼接外部地址；三级域名不再硬编码，从懒猫应用返回的 `domain/subdomain` 自动提取（如 canway / nasw）。
 - 2026-06-25：修复中英文切换下侧栏菜单不跟随语言的问题，导航文案改为双语字段并通过 `t(...)` 动态渲染（Overview / Management / Access tokens / Observability）。
+- 2026-06-25：资源管理“打开”按钮切换为自动模式，不再依赖 app_id 白名单；优先使用 app.subdomain 推导前缀，回退到 app.domain 推导。

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -69,11 +69,6 @@ let mediaQueryList = null
 let mediaQueryHandler = null
 let toastTimer = null
 const TOKEN_SECRET_STORAGE_KEY = 'lazycat-mcp-token-secrets'
-const OPEN_APP_TARGETS = {
-  'cloud.lazycat.app.lazycat-filedrop-skill': 'lazycat-filedrop',
-  'cloud.lazycat.app.lazycat-agent-browser-skill': 'lazycat-agent-browser'
-}
-
 const t = (zh, en) => state.language === 'en' ? en : zh
 
 function setLang(lang) {
@@ -271,7 +266,17 @@ function rootDomainFromHost(host) {
   return normalized
 }
 function openTargetPrefix(row) {
-  return OPEN_APP_TARGETS[row?.appId || row?.app?.app_id] || ''
+  const subdomain = normalizeDomain(row?.app?.subdomain)
+  if (subdomain) {
+    const first = subdomain.split('.').filter(Boolean)[0]
+    if (first) return first
+  }
+  const domain = normalizeDomain(row?.app?.domain)
+  if (domain) {
+    const parts = domain.split('.').filter(Boolean)
+    if (parts.length >= 3) return parts[0]
+  }
+  return ''
 }
 function openRootDomain(row) {
   const fromDomain = rootDomainFromHost(row?.app?.domain)


### PR DESCRIPTION
## 变更
- 打开按钮改为自动模式（基于 app.subdomain/domain 推导）
- 侧栏菜单支持中英文切换
- 保留并完善资源管理打开能力

## 验证
- [x] npm run build
- [x] /usr/local/go/bin/go test ./...

## 产物
- 已打包最新 LPK 供测试
