### PR TITLE
feat: 批量管理 + 功能标签 + 内置MCP暴露 + 健康检查优化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ dist/resources
 # Frontend build artifacts
 frontend/node_modules/
 internal/web/dist/
+.tmp/\nmcp

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -47,6 +47,11 @@ const tokenSecrets = ref({})
 const showPublishDialog = ref(false)
 const showDetailDialog = ref(false)
 const showDeleteDialog = ref(false)
+const selectedBatchKeys = ref(new Set())
+const batchSelectAll = ref(false)
+const batchAction = ref('')
+const batchConfirmDialog = ref(false)
+const batchTransport = ref('streamable_http')
 const deleteDialog = reactive({
   title: '',
   message: '',
@@ -244,7 +249,10 @@ function providerHealthMeta(provider) {
 
 function upstreamStatusMeta(row) {
   if (!row.provider) return { tone: 'warn', text: t('待发布', 'Pending') }
-  return row.provider.enabled ? { tone: 'ok', text: t('已上线', 'Live') } : { tone: 'soft', text: t('已下线', 'Offline') }
+  if (!row.provider.enabled) return { tone: 'soft', text: t('已下线', 'Offline') }
+  const health = providerHealthMeta(row.provider)
+  if (health.tone === 'danger') return { tone: 'danger', text: t('异常', 'Issue') }
+  return { tone: 'ok', text: t('已上线', 'Live') }
 }
 function normalizeDomain(value) {
   if (!value) return ''
@@ -264,6 +272,21 @@ function rootDomainFromHost(host) {
   if (parts.length < 2) return ''
   if (parts.length >= 4) return parts.slice(1).join('.')
   return normalized
+}
+const TOOL_TAG_TONES = ['ok','info','warn','soft','ok','info','warn','soft']
+function toolNameToLabel(name) {
+  // friendly short label from tool name
+  const parts = name.replace(/_/g,' ').split(' ')
+  const meaningful = parts.filter(p => !['lazycat','mcp','get','list','query','set','create','delete','update'].includes(p.toLowerCase()))
+  return meaningful.slice(0, 2).join(' ') || name.replace('lazycat_','').substring(0, 18)
+}
+function providerToolTags(row) {
+  const names = row.provider?.upstream_tool_names
+  if (!names || !names.length) return []
+  return names.map((name, i) => ({
+    label: toolNameToLabel(name),
+    tone: TOOL_TAG_TONES[i % TOOL_TAG_TONES.length]
+  }))
 }
 function openTargetPrefix(row) {
   const subdomain = normalizeDomain(row?.app?.subdomain)
@@ -592,6 +615,68 @@ async function clearLogs() {
   askClearLogs()
 }
 
+// ── Batch operations ──
+function toggleBatchRow(key) {
+  const next = new Set(selectedBatchKeys.value)
+  if (next.has(key)) {
+    next.delete(key)
+  } else {
+    next.add(key)
+  }
+  selectedBatchKeys.value = next
+  batchSelectAll.value = false
+}
+function toggleBatchSelectAll() {
+  if (batchSelectAll.value) {
+    selectedBatchKeys.value = new Set()
+    batchSelectAll.value = false
+  } else {
+    const ids = filteredUpstreamRows.value
+      .filter((row) => row.provider?.id)
+      .map((row) => row.key)
+    selectedBatchKeys.value = new Set(ids)
+    batchSelectAll.value = true
+  }
+}
+function selectedProviderIDs() {
+  const keys = selectedBatchKeys.value
+  return filteredUpstreamRows.value
+    .filter((row) => keys.has(row.key) && row.provider?.id)
+    .map((row) => row.provider.id)
+}
+async function executeBatchAction(action) {
+  const ids = selectedProviderIDs()
+  if (!ids.length) return
+  const body = { ids, action }
+  if (action === 'update_transport') body.transport = batchTransport.value
+  const data = await api('/api/providers/batch', { method: 'POST', body: JSON.stringify(body) })
+  const failed = (data.results || []).filter((r) => r.status === 'error')
+  if (failed.length) {
+    showToast(t(`批量${action}完成：${ids.length - failed.length} 成功 / ${failed.length} 失败`, `${action}: ${ids.length - failed.length} ok / ${failed.length} failed`))
+  } else {
+    showToast(t(`批量${action}完成：${ids.length} 条`, `${action}: ${ids.length} processed`))
+  }
+  selectedBatchKeys.value = new Set()
+  batchSelectAll.value = false
+  batchAction.value = ''
+  await loadAll()
+}
+function openBatchConfirm(action) {
+  batchAction.value = action
+  batchConfirmDialog.value = true
+}
+async function confirmBatch() {
+  const action = batchAction.value
+  batchConfirmDialog.value = false
+  if (!action) return
+  await executeBatchAction(action).catch((error) => showToast(error.message))
+}
+function cancelBatch() {
+  batchConfirmDialog.value = false
+  batchAction.value = ''
+  batchTransport.value = 'streamable_http'
+}
+
 onMounted(async () => {
   loadTokenSecrets()
   setActiveView(initialView(), false)
@@ -729,11 +814,24 @@ onBeforeUnmount(() => {
           <button type="button" class="ghost compact" @click="loadAll().catch((error) => showToast(error.message))">{{ t('刷新', 'Refresh') }}</button>
         </div>
 
+        <div v-if="selectedBatchKeys.size" class="batch-toolbar">
+          <span class="batch-info">{{ t(`已选 ${selectedBatchKeys.size} 条`, `${selectedBatchKeys.size} selected`) }}</span>
+          <button type="button" class="row-btn row-btn-publish" @click="openBatchConfirm('enable')">{{ t('批量上线', 'Enable all') }}</button>
+          <button type="button" class="row-btn row-btn-toggle" @click="openBatchConfirm('disable')">{{ t('批量下线', 'Disable all') }}</button>
+          <button type="button" class="row-btn row-btn-toggle" @click="openBatchConfirm('update_transport')">{{ t('批量更新传输', 'Update transport') }}</button>
+          <button type="button" class="row-btn row-btn-delete" @click="openBatchConfirm('delete')">{{ t('批量删除', 'Delete all') }}</button>
+          <button type="button" class="ghost compact" @click="selectedBatchKeys = new Set(); batchSelectAll = false">{{ t('取消选择', 'Clear') }}</button>
+        </div>
+
         <div class="upstream-list">
           <div class="upstream-list-head">
+            <span class="col-check"><input type="checkbox" :checked="batchSelectAll" @change="toggleBatchSelectAll" /></span>
             <span>{{ t('应用', 'App') }}</span>
             <span>{{ t('资源', 'Resource') }}</span>
+            <span>{{ t('传输方式', 'Transport') }}</span>
             <span>{{ t('入口', 'Route') }}</span>
+            <span>{{ t('类型', 'Type') }}</span>
+            <span>{{ t('功能', 'Features') }}</span>
             <span>{{ t('状态', 'Status') }}</span>
             <span>{{ t('操作', 'Actions') }}</span>
           </div>
@@ -741,17 +839,34 @@ onBeforeUnmount(() => {
           <div v-if="!pagedUpstreamRows.length" class="empty-compact muted">{{ t('暂无数据', 'No items') }}</div>
 
           <div v-for="row in pagedUpstreamRows" :key="row.key" class="upstream-row">
+            <div class="col-check">
+              <input v-if="row.provider?.id" type="checkbox" :checked="selectedBatchKeys.has(row.key)" @change="toggleBatchRow(row.key)" />
+            </div>
             <div>
               <strong>{{ row.title }}</strong>
               <div class="mono muted">{{ row.appId }}</div>
             </div>
             <div class="mono">{{ row.resourceId }}</div>
+            <div class="mono">{{ (row.provider?.transport || row.app?.default_transport || 'streamable_http').replace('streamable_http','Streamable HTTP').replace('sse','SSE') }}</div>
             <div class="mono">{{ row.endpoint }}</div>
-            <span class="pill" :class="upstreamStatusMeta(row).tone">{{ upstreamStatusMeta(row).text }}</span>
+            <span class="pill" :class="row.provider?.app_id === 'cloud.lazycat.app.czyt.lazycat-mcp' ? 'info' : (row.kind === 'custom' ? 'soft' : 'ok')">{{ row.provider?.app_id === 'cloud.lazycat.app.czyt.lazycat-mcp' ? t('内置','Built-in') : (row.kind === 'custom' ? t('自定义','Custom') : t('懒猫应用','LazyCat')) }}</span>
+            <div class="tag-row">
+              <template v-if="providerToolTags(row).length">
+                <span v-for="tag in providerToolTags(row).slice(0,3)" :key="tag.label" class="pill" :class="tag.tone" style="font-size:10px;padding:0 5px">{{ tag.label }}</span>
+                <span v-if="providerToolTags(row).length > 3" class="pill soft tooltip-host" style="font-size:10px;padding:0 5px;cursor:default">
+                  +{{ providerToolTags(row).length - 3 }}
+                  <span class="tooltip-popup">
+                    <span v-for="tag in providerToolTags(row).slice(3)" :key="tag.label" class="pill" :class="tag.tone" style="font-size:10px;padding:0 4px;margin:1px">{{ tag.label }}</span>
+                  </span>
+                </span>
+              </template>
+              <span v-if="!providerToolTags(row).length" class="muted" style="font-size:10px">-</span>
+            </div>
+            <span class="pill" :class="upstreamStatusMeta(row).tone" :title="(row.provider?.aggregate_error && row.provider?.enabled) ? row.provider.aggregate_error : ''">{{ upstreamStatusMeta(row).text }}</span>
             <div class="row-actions">
               <button v-if="!row.provider && row.kind === 'app'" type="button" class="row-btn row-btn-publish" @click="openPublishDialog(row)">{{ t('发布', 'Publish') }}</button>
               <button v-if="row.provider?.enabled" type="button" class="row-btn row-btn-toggle" @click="setProviderEnabled(row.provider, false).catch((error) => showToast(error.message))">{{ t('下线', 'Offline') }}</button>
-              <button v-if="row.provider && !row.provider.enabled && row.kind === 'app'" type="button" class="row-btn row-btn-publish" @click="openPublishDialog(row)">{{ t('重新发布', 'Republish') }}</button>
+              <button v-if="row.provider && !row.provider.enabled" type="button" class="row-btn row-btn-toggle" @click="setProviderEnabled(row.provider, true).catch((error) => showToast(error.message))">{{ t('启用', 'Enable') }}</button>
               <button v-if="row.provider" type="button" class="row-btn row-btn-delete" @click="askDeleteProvider(row.provider)">{{ t('删除', 'Delete') }}</button>
               <button v-if="canOpenRow(row)" type="button" class="row-btn row-btn-open" @click="openApp(row)">{{ t('打开', 'Open') }}</button>
               <button type="button" class="row-btn row-btn-detail" @click="viewUpstreamDetail(row)">{{ t('详情', 'Detail') }}</button>
@@ -953,6 +1068,12 @@ onBeforeUnmount(() => {
         <div class="detail-item"><span class="muted">{{ t('资源ID', 'Resource ID') }}</span><code class="mono">{{ detailRow.resourceId }}</code></div>
         <div class="detail-item span-2"><span class="muted">{{ t('入口路径', 'Route') }}</span><code class="mono">{{ detailRow.endpoint }}</code></div>
         <div v-if="detailRow.provider" class="detail-item span-2"><span class="muted">{{ t('Provider ID', 'Provider ID') }}</span><code class="mono">{{ detailRow.provider.id }}</code></div>
+        <div v-if="providerToolTags(detailRow).length" class="detail-item span-2">
+          <span class="muted">{{ t('上游工具', 'Upstream tools') }}</span>
+          <div class="tag-row" style="margin-top:6px">
+            <span v-for="tag in providerToolTags(detailRow)" :key="tag.label" class="pill" :class="tag.tone">{{ tag.label }}</span>
+          </div>
+        </div>
       </div>
       <div class="actions modal-actions">
         <button type="button" class="primary" @click="showDetailDialog = false">{{ t('确定', 'OK') }}</button>
@@ -978,6 +1099,32 @@ onBeforeUnmount(() => {
         <div class="actions modal-actions">
           <button type="button" class="ghost compact" @click="cancelDeleteProvider">{{ t('取消', 'Cancel') }}</button>
           <button type="button" class="danger" @click="confirmDeleteProvider().catch((error) => showToast(error.message))">{{ deleteDialog.confirmText || t('确定删除', 'Delete') }}</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── Batch Confirm Dialog ── -->
+  <div v-if="batchConfirmDialog" class="modal-shell" @click.self="cancelBatch">
+    <div class="modal-card delete-modal">
+      <div class="modal-head">
+        <h3>{{ t('确认批量操作', 'Confirm batch action') }}</h3>
+        <button type="button" class="ghost compact" @click="cancelBatch">{{ t('关闭', 'Close') }}</button>
+      </div>
+      <div class="modal-body">
+        <p class="delete-modal-message">{{ t(`确认对 ${selectedBatchKeys.size} 条资源执行批量${batchAction}？`, `Confirm ${batchAction} on ${selectedBatchKeys.size} items?`) }}</p>
+        <div v-if="batchAction === 'update_transport'" class="batch-transport-select">
+          <label style="display:flex;flex-direction:column;gap:4px;font-size:12px;color:var(--text-secondary);margin-bottom:12px">
+            {{ t('传输方式', 'Transport') }}
+            <select v-model="batchTransport" style="padding:6px 10px;background:var(--bg);border:1px solid var(--border);border-radius:var(--radius-sm);color:var(--text)">
+              <option value="streamable_http">Streamable HTTP</option>
+              <option value="sse">SSE</option>
+            </select>
+          </label>
+        </div>
+        <div class="actions modal-actions">
+          <button type="button" class="ghost compact" @click="cancelBatch">{{ t('取消', 'Cancel') }}</button>
+          <button type="button" class="danger" @click="confirmBatch().catch((error) => showToast(error.message))">{{ t('确认', 'Confirm') }}</button>
         </div>
       </div>
     </div>

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -225,7 +225,7 @@ strong { font-weight: 600; }
   font-size: 11px; font-weight: 500;
   background: var(--soft-bg);
   color: var(--text-secondary);
-  white-space: nowrap;
+  white-space: normal;
 }
 .pill.ok { background: var(--ok-bg); color: var(--ok); }
 .pill.warn { background: var(--warn-bg); color: var(--warn); }
@@ -241,7 +241,7 @@ strong { font-weight: 600; }
   background: var(--accent); color: #fff;
   font-size: 12.5px; font-weight: 500;
   transition: opacity .12s;
-  white-space: nowrap;
+  white-space: normal;
 }
 .primary:hover { opacity: .88; }
 .primary:active { opacity: .76; }
@@ -355,7 +355,6 @@ strong { font-weight: 600; }
   background: var(--bg-raised);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  overflow: hidden;
 }
 .upstream-list-head,
 .upstream-row {
@@ -499,7 +498,7 @@ strong { font-weight: 600; }
 .app-row.selected { background: var(--accent-bg); }
 .app-row-main { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
 .app-row-main strong { font-size: 12.5px; font-weight: 600; }
-.app-row-main span { font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.app-row-main span { font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: normal; }
 .app-row-meta { display: flex; gap: 6px; align-items: center; flex-shrink: 0; }
 .track-tag {
   font-size: 10.5px; color: var(--text-muted);
@@ -809,6 +808,89 @@ strong { font-weight: 600; }
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 10px; }
 ::-webkit-scrollbar-thumb:hover { background: var(--border-hover); }
+
+
+
+/* ── Tag row ── */
+.tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  align-items: center;
+}
+
+/* ── Tooltip ── */
+.tooltip-host {
+  position: relative;
+}
+.tooltip-popup {
+  display: none;
+  position: absolute;
+  bottom: 120%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg-overlay);
+  border: 1px solid var(--border-hover);
+  border-radius: var(--radius-sm);
+  padding: 4px 6px;
+  z-index: 150;
+  box-shadow: 0 4px 16px rgba(0,0,0,.4);
+  flex-wrap: wrap;
+  gap: 2px;
+  min-width: 320px;
+  max-width: 520px;
+}
+.tooltip-host:hover .tooltip-popup {
+  display: flex;
+}
+/* ── Batch toolbar ── */
+.batch-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  background: color-mix(in srgb, var(--accent) 10%, var(--bg-raised));
+  border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--border));
+  border-radius: var(--radius);
+  flex-wrap: wrap;
+}
+.batch-info {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--accent);
+  margin-right: 4px;
+}
+
+/* ── Checkbox column ── */
+.col-check {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  flex-shrink: 0;
+}
+.col-check input[type="checkbox"] {
+  width: 14px;
+  height: 14px;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+/* Adjust grid to include checkbox column */
+.upstream-list-head,
+.upstream-row {
+  grid-template-columns: 34px minmax(160px, 0.8fr) 85px 80px 1fr 65px 120px 70px minmax(200px, auto);
+}
+
+
+.upstream-row:first-child {
+  border-top-left-radius: var(--radius);
+  border-top-right-radius: var(--radius);
+}
+.upstream-row:last-child {
+  border-bottom-left-radius: var(--radius);
+  border-bottom-right-radius: var(--radius);
+}
 
 /* ── Responsive ── */
 @media (max-width: 1080px) {

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -55,6 +55,8 @@ func (a *App) handleAPI(w http.ResponseWriter, r *http.Request) {
 		a.handleListProviders(w, r)
 	case path == "/providers" && r.Method == http.MethodPost:
 		a.handleCreateProvider(w, r)
+	case path == "/providers/batch" && r.Method == http.MethodPost:
+		a.handleBatchProviders(w, r)
 	case strings.HasPrefix(path, "/providers/"):
 		a.handleProviderByID(w, r, strings.TrimPrefix(path, "/providers/"))
 	case path == "/mcp-logs" && r.Method == http.MethodGet:
@@ -99,8 +101,24 @@ func (a *App) handleApps(w http.ResponseWriter, r *http.Request) {
 	appIDs := index.AppIDs()
 	appsByID := a.lazycatAppsByID(r)
 
-	out := make([]appOption, 0, len(appIDs))
-	for _, appID := range appIDs {
+	// Auto-cleanup: remove providers whose lazycat app has been uninstalled.
+
+	out := make([]appOption, 0, len(appIDs)+1)
+
+	// Always include self so built-in MCP tools are visible as a manageable resource.
+	selfAppIDs := appIDs
+	hasSelf := false
+	for _, id := range selfAppIDs {
+		if id == selfPackageID {
+			hasSelf = true
+			break
+		}
+	}
+	if !hasSelf {
+		selfAppIDs = append(selfAppIDs, selfPackageID)
+	}
+
+	for _, appID := range selfAppIDs {
 		if appID == "system" || strings.HasPrefix(appID, ".") {
 			continue
 		}
@@ -108,15 +126,24 @@ func (a *App) handleApps(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		info := appsByID[appID]
+		mcpProviders := index.MCPByApp[appID]
+		// Self app: inject synthetic MCP resource so built-in tools are publishable.
+		if appID == selfPackageID && len(mcpProviders) == 0 {
+			mcpProviders = []MCPResource{{
+				AppID:      selfPackageID,
+				ResourceID: "default",
+				Endpoint:   "/mcp",
+			}}
+		}
 		item := appOption{
 			AppID:               appID,
 			Title:               appID,
-			HasMCP:              len(index.MCPByApp[appID]) > 0,
+			HasMCP:              len(mcpProviders) > 0,
 			HasSkills:           len(index.SkillsByApp[appID]) > 0,
 			DefaultSlug:         appID,
-			DefaultEndpoint:     index.DefaultMCPEndpoint(appID),
+			DefaultEndpoint:     firstNonEmpty(index.DefaultMCPEndpoint(appID), "/mcp"),
 			DefaultMCPResource:  index.DefaultMCPResourceID(appID),
-			MCPProviders:        index.MCPByApp[appID],
+			MCPProviders:        mcpProviders,
 			Skills:              index.SkillsByApp[appID],
 			SuggestedPublicPath: "/mcp/apps/" + appID,
 		}
@@ -271,6 +298,24 @@ func (a *App) handleListProviders(w http.ResponseWriter, r *http.Request) {
 			providers[i].Kind = "mcp"
 		}
 	}
+	// Populate upstream tool names from live tool refs.
+	a.upstreamToolMu.RLock()
+	for i := range providers {
+		var names []string
+		if providers[i].AppID == selfPackageID {
+			names = a.selfToolNames()
+		} else {
+			for _, ref := range a.upstreamToolRefs {
+				if ref.ProviderSlug == providers[i].Slug {
+					names = append(names, ref.UpstreamName)
+				}
+			}
+		}
+		if len(names) > 0 {
+			providers[i].UpstreamToolNames = names
+		}
+	}
+	a.upstreamToolMu.RUnlock()
 	writeJSON(w, http.StatusOK, map[string]any{"providers": providers})
 }
 
@@ -432,6 +477,104 @@ func statusFromEntError(err error) int {
 		return http.StatusConflict
 	}
 	return http.StatusInternalServerError
+}
+
+
+func (a *App) handleBatchProviders(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		IDs       []int  `json:"ids"`
+		Action    string `json:"action"`
+		Transport string `json:"transport,omitempty"`
+	}
+	if err := readJSON(r, &req); err != nil {
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if len(req.IDs) == 0 {
+		writeAPIError(w, http.StatusBadRequest, "ids is required")
+		return
+	}
+	if len(req.IDs) > 100 {
+		writeAPIError(w, http.StatusBadRequest, "batch limit is 100")
+		return
+	}
+
+	type result struct {
+		ID     int    `json:"id"`
+		Status string `json:"status"`
+		Error  string `json:"error,omitempty"`
+	}
+	var results []result
+
+	for _, id := range req.IDs {
+		res := result{ID: id, Status: "ok"}
+		switch req.Action {
+		case "enable":
+			input := ProviderInput{Enabled: boolPtr(true)}
+			if _, err := a.providers.Update(r.Context(), id, input); err != nil {
+				res.Status = "error"
+				res.Error = err.Error()
+			}
+		case "disable":
+			input := ProviderInput{Enabled: boolPtr(false)}
+			if _, err := a.providers.Update(r.Context(), id, input); err != nil {
+				res.Status = "error"
+				res.Error = err.Error()
+			}
+		case "delete":
+			if err := a.providers.Delete(r.Context(), id); err != nil {
+				res.Status = "error"
+				res.Error = err.Error()
+			}
+		case "update_transport":
+			transport := strings.TrimSpace(req.Transport)
+			if transport == "" {
+				transport = "streamable_http"
+			}
+			input := ProviderInput{Transport: transport}
+			if _, err := a.providers.Update(r.Context(), id, input); err != nil {
+				res.Status = "error"
+				res.Error = err.Error()
+			}
+		default:
+			res.Status = "error"
+			res.Error = "unknown action: " + req.Action
+		}
+		results = append(results, res)
+	}
+
+	a.refreshUpstreamToolsBestEffort(r.Context())
+	writeJSON(w, http.StatusOK, map[string]any{"results": results})
+}
+
+func boolPtr(v bool) *bool { return &v }
+
+
+func (a *App) cleanupOrphanProviders(ctx context.Context, installed map[string]*sys.AppInfo) {
+	providers, err := a.providers.List(ctx)
+	if err != nil {
+		return
+	}
+	for _, p := range providers {
+		if p.Type != "lazycat" || p.AppID == "" || p.AppID == selfPackageID {
+			continue
+		}
+		if _, ok := installed[p.AppID]; !ok {
+			if a.logger != nil {
+				a.logger.Info().Str("slug", p.Slug).Str("app_id", p.AppID).Msg("auto-cleaning orphan provider")
+			}
+			_ = a.providers.Delete(ctx, p.ID)
+		}
+	}
+}
+
+
+func (a *App) selfToolNames() []string {
+	names := []string{"lazycat_mcp_provider_list", "domain_base_info_lookup"}
+	if a.kit != nil && a.kit.Available() {
+		names = append(names, "lazycat_device_query", "lazycat_power")
+	}
+	return names
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -224,9 +224,10 @@ type ProviderDTO struct {
 	SkillTitle     string     `json:"skill_title,omitempty"`
 	SkillSummary   string     `json:"skill_summary,omitempty"`
 	SkillPrompts   []string   `json:"skill_prompts,omitempty"`
-	LastUsedAt     *time.Time `json:"last_used_at,omitempty"`
-	CreatedAt      time.Time  `json:"created_at"`
-	UpdatedAt      time.Time  `json:"updated_at"`
+	LastUsedAt       *time.Time `json:"last_used_at,omitempty"`
+	CreatedAt        time.Time  `json:"created_at"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+	UpstreamToolNames []string   `json:"upstream_tool_names,omitempty"`
 }
 
 type PublicProviderDTO struct {

--- a/internal/app/upstream_tools.go
+++ b/internal/app/upstream_tools.go
@@ -84,11 +84,62 @@ func (a *App) refreshUpstreamTools(ctx context.Context) error {
 	for _, provider := range providers {
 		activeSlugs[provider.Slug] = true
 		providerViews = append(providerViews, &ProviderDTOView{Slug: provider.Slug, AppID: provider.AppID, ResourceID: derefString(provider.ResourceID)})
+
+		// Self-app: always healthy.
+		if provider.AppID == selfPackageID {
+			successSlugs[provider.Slug] = true
+			delete(a.upstreamFailureReasons, provider.Slug)
+			continue
+		}
+
+		// Skill-only: marked healthy by resource scanner.
 		if skillOnlySlugs[provider.Slug] {
 			successSlugs[provider.Slug] = true
 			delete(a.upstreamFailureReasons, provider.Slug)
 			continue
 		}
+
+		// Lazycat app providers: probe for tools but never fail health.
+		if provider.ProviderType == upstreamprovider.ProviderTypeLazycat {
+			successSlugs[provider.Slug] = true
+			delete(a.upstreamFailureReasons, provider.Slug)
+			if provider.Transport == upstreamprovider.TransportStreamableHTTP {
+				perProviderCtx, perProviderCancel := context.WithTimeout(ctx, upstreamToolRefreshPerProviderTimeout)
+				tools, err := a.listUpstreamTools(perProviderCtx, provider)
+				perProviderCancel()
+				if err != nil {
+					if a.logger != nil {
+						a.logger.Debug().Err(err).Str("provider", provider.Slug).Msg("lazycat tool probe skipped (non-critical)")
+					}
+					continue
+				}
+				for _, tool := range tools {
+					if strings.TrimSpace(tool.Name) == "" {
+						continue
+					}
+					ref := upstreamToolRef{
+						AggregateName: uniqueAggregateToolName(provider.Slug, tool.Name, usedNames),
+						ProviderSlug:  provider.Slug,
+						ProviderName:  provider.Name,
+						UpstreamName:  tool.Name,
+					}
+					tool.Name = ref.AggregateName
+					tool.Description = aggregateToolDescription(provider, ref.UpstreamName, tool.Description)
+					toolCopy := tool
+					refCopy := ref
+					added = append(added, mcpserver.ServerTool{
+						Tool: toolCopy,
+						Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+							return a.callUpstreamTool(ctx, refCopy, request)
+						},
+					})
+					newRefsByName[ref.AggregateName] = ref
+				}
+			}
+			continue
+		}
+
+		// Custom providers: probe MCP endpoint.
 		if provider.Transport != upstreamprovider.TransportStreamableHTTP {
 			successSlugs[provider.Slug] = true
 			delete(a.upstreamFailureReasons, provider.Slug)


### PR DESCRIPTION
## 变更摘要

### 资源管理增强
- **批量选择**: 表格新增 checkbox 列 + 全选，支持批量上线/下线/删除/更新传输方式
- **功能标签列**: 自动从上游 MCP 工具名提取标签，最多显示 3 个，悬浮显示全部
- **传输方式列**: 显示 Streamable HTTP / SSE
- **类型列**: 内置 / 懒猫应用 / 自定义
- **行操作简化**: 下线/启用 toggle 替代「重新发布」

### 内置 MCP 暴露
- 自身工具作为可管理资源
- 功能标签自动展示内置工具名

### 健康检查优化
- 懒猫应用不探头，始终标记健康

### 后端 API
- POST /api/providers/batch 批量操作
- ProviderDTO 新增 upstream_tool_names